### PR TITLE
fix: tiny fix in yhdm_adapter

### DIFF
--- a/lib/adapters/yhdm_adapter.dart
+++ b/lib/adapters/yhdm_adapter.dart
@@ -79,11 +79,15 @@ class YhdmAdapter extends AdapterBase {
     var doc = parse(html);
     // Yhdm has multiple video sources, we use the second for now.
     var ul;
+    int i = 0;
     for (final div in doc.getElementsByClassName('movurl')) {
       final temp = div.querySelector('ul');
       if (temp?.children.isNotEmpty ?? false) {
         ul = temp!;
-        break;
+        if (i == 1) {
+          break;
+        }
+        i++;
       }
     }
     List<Episode> ret = [];
@@ -168,6 +172,6 @@ class YhdmAdapter extends AdapterBase {
 
   YhdmAdapter()
       : super(
-          '樱花动漫',
+          'Sakura',
         );
 }


### PR DESCRIPTION
1. 默认选择播放列表中，非空的第二个视频源，而非非空的第一个视频源。这是由于樱花动漫第一个播放列表的资源失效率非常高，或者是只有PV。樱花动漫本身基本不把第一个源作为默认源。（测试用例： 葬送的芙莉莲）
2. 修改樱花动漫适配器的名称以让其看起来不那么突兀。